### PR TITLE
Remove bower

### DIFF
--- a/README.org
+++ b/README.org
@@ -88,5 +88,4 @@ A list of package manager.
 | [[https://www.qt.io/][QT]]          | [[https://www.qt.io/download][Download]]  | [[https://inqlude.org/get.html][inqlude]]           | [[https://inqlude.org/][#inqlude]]     |
 | [[https://coreos.com/rkt/][Rocket(rkt)]] | [[https://github.com/rkt/rkt][Download]]  | rkt(Built-in)     | [[https://hub.docker.com/][Docker Hub]]   |
 | [[https://unity3d.com/][Unity3D]]     | [[https://unity3d.com/][Download]]  | [[https://github.com/modesttree/projeny][Projeny]]           | [[https://www.assetstore.unity3d.com/][Asset Store]]  |
-| Web         | None      | [[https://bower.io/][Bower]]             | [[https://bower.io/search/][Bower Search]] |
 | [[https://wordpress.org/][WordPress]]   | [[https://wordpress.org/download/][Download]]  | Built-in          | [[https://libraries.io/wordpress][Plugins]]      |


### PR DESCRIPTION
Bower is deprecated:

![grafik](https://user-images.githubusercontent.com/1366654/35745388-6fecddae-0843-11e8-9522-48cdc46347b9.png)

Not sure whether [jam](http://www.jamjs.org/) is the appropriate replacement. It is, however, listed in the other category.
