### PR TITLE
Add Meta Package Manager

### DIFF
--- a/README.org
+++ b/README.org
@@ -282,6 +282,7 @@ A list of package manager.
 | *[[https://tiswww.case.edu/php/chet/bash/bashtop.html][Bash-it]]*     | [[https://github.com/Bash-it/bash-it][Install]]   | bash-it           | [[https://github.com/Bash-it/bash-it/wiki/Themes][Themes]]      |
 | *[[http://www.zsh.org/][Oh-my-zsh]]*   | [[https://github.com/robbyrussell/oh-my-zsh][Install]]   | [[http://antigen.sharats.me/][Antigen]]           | [[https://github.com/unixorn/awesome-zsh-plugins#plugins][Plugins]]     |
 | IoT           | None      | [[http://platformio.org/][PlatformaIO]]       | [[http://platformio.org/lib][Libraries]]   |
+| [[https://github.com/kdeldycke/meta-package-manager][Meta Package Manager]]       | [[https://kdeldycke.github.io/meta-package-manager/install.html][Install]]       | A lot | None        |
 | [[https://nanobox.io/][Nanobox]]       | [[https://nanobox.io/pricing/][Buy]]       | nanobox(Built-in) | None        |
 | [[https://puppet.com/][Puppet]]        | [[https://puppet.com/download-puppet-enterprise][Download]]  | [[https://forge.puppet.com/][Forge]](Built-in)   | [[https://forge.puppet.com/][PuppetForge]] |
 | [[http://reaper.fm/index.php][REAPER]]        | [[http://reaper.fm/download.php][Download]]  | [[https://github.com/cfillion/reapack][Reapack]]           | [[https://reapack.com/repos][Repos]]       |


### PR DESCRIPTION
Meta Package Manager provides the `mpm` CLI, a wrapper around all package managers.